### PR TITLE
resolved #1

### DIFF
--- a/SPSlideTabBarController/SPSlideTabBarController/SPSlideTabBar/SPSlideTabBar.m
+++ b/SPSlideTabBarController/SPSlideTabBarController/SPSlideTabBar/SPSlideTabBar.m
@@ -162,9 +162,6 @@
     [buttons enumerateObjectsUsingBlock:^(UIButton *button, NSUInteger index, BOOL *stop) {
         if (button == sender) {
             [self selectTabAtIndex:index];
-            if (self.delegate && [self.delegate respondsToSelector:@selector(slideTabBar:didSelectIndex:)]) {
-                [self.delegate slideTabBar:self didSelectIndex:index];
-            }
             *stop = YES;
         }
     }];
@@ -240,6 +237,11 @@
     }
     
     _selectedTabIndex = index;
+    
+    // notify delegate that the selection has been done.
+    if (self.delegate && [self.delegate respondsToSelector:@selector(slideTabBar:didSelectIndex:)]) {
+        [self.delegate slideTabBar:self didSelectIndex:index];
+    }
 }
 
 /**

--- a/SPSlideTabBarController/SPSlideTabBarController/SPSlideTabBarController.m
+++ b/SPSlideTabBarController/SPSlideTabBarController/SPSlideTabBarController.m
@@ -63,6 +63,9 @@
  */
 - (void)addViewController:(nonnull UIViewController *)viewController atIndex:(NSUInteger)tabIndex {
     
+    // judge if there is none viewControllers before add
+    BOOL isTheFirstViewController = (self.viewControllers.count == 0);
+    
     NSUInteger index = tabIndex;
     if (index > self.viewControllers.count) {
         index = self.viewControllers.count;
@@ -78,6 +81,11 @@
     
     if ([self isViewLoaded]) {
         
+        // if slide tab bar view controller has loaded, and the first view controller is added after that,
+        // make the first view controller visible manually, otherwise it will not been visible untill tab is clicked.
+        if (isTheFirstViewController) {
+            [self _makeViewControllerVisibleAtIndex:index];
+        }
     }
 }
 


### PR DESCRIPTION
resolved #1
1. [fix] if the first viewController is added after slide tab bar controller loaded, the first viewController will not be visible untill tabbar dragged.
2. [fix] programically calling the method [selectTabAtIndex:] will not make the childview controller visible untill tabbar dragged.