### PR TITLE
Adds method to change indicator line color

### DIFF
--- a/SPSlideTabBarController/SPSlideTabBarController/SPSlideTabBar/SPSlideTabBar.m
+++ b/SPSlideTabBarController/SPSlideTabBarController/SPSlideTabBar/SPSlideTabBar.m
@@ -335,12 +335,22 @@
     }
 }
 
+/**
+ * changes indicator color
+ *
+ *
+*/
+- (void)changeIndicatorColor:(UIColor *)color {
+    self.indicatorLine.backgroundColor = color;
+}
+    
+    
 #pragma mark - getter
-
+    
 - (CGSize)intrinsicContentSize {
     return CGSizeMake(UIViewNoIntrinsicMetric, 44);
 }
-
+    
 - (NSArray <UIButton *> *)tabBarButtonSubviews {
     NSMutableArray <UIButton *> *buttons = [NSMutableArray array];
     for (UIView *view in self.scrollView.subviews) {
@@ -350,7 +360,7 @@
     }
     return buttons;
 }
-
+    
 @end
 
 

--- a/SPSlideTabBarController/SPSlideTabBarController/SPSlideTabBar/SPSlideTabBarProtocol.h
+++ b/SPSlideTabBarController/SPSlideTabBarController/SPSlideTabBar/SPSlideTabBarProtocol.h
@@ -89,4 +89,11 @@
  */
 - (void)fixIndicatorWithScrollOffset:(CGFloat)offset;
 
+/**
+ * changes indicator color
+ *
+ *
+*/
+- (void)changeIndicatorColor:(UIColor*)color;
+
 @end

--- a/SPSlideTabBarControllerDemo/SPSlideTabBarControllerDemo.xcodeproj/project.pbxproj
+++ b/SPSlideTabBarControllerDemo/SPSlideTabBarControllerDemo.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		6F1551911C7B0AE500B9EBBC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F15518B1C7B0AE500B9EBBC /* main.m */; };
 		6F1551951C7B0AEF00B9EBBC /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6F1551931C7B0AEF00B9EBBC /* Info.plist */; };
 		6F15519A1C7B0AF300B9EBBC /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6F1551981C7B0AF300B9EBBC /* Info.plist */; };
-		6F15519F1C7B0C8500B9EBBC /* libSPSlideTabBarController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F15519E1C7B0C8500B9EBBC /* libSPSlideTabBarController.a */; };
+		A1DC626D2026DBF500CB7E07 /* libSPSlideTabBarController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A1DC626E2026DBF500CB7E07 /* libSPSlideTabBarController.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,10 +60,10 @@
 		6F1551941C7B0AEF00B9EBBC /* SPSlideTabBarControllerDemoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPSlideTabBarControllerDemoTests.m; sourceTree = "<group>"; };
 		6F1551981C7B0AF300B9EBBC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F1551991C7B0AF300B9EBBC /* SPSlideTabBarControllerDemoUITests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPSlideTabBarControllerDemoUITests.m; sourceTree = "<group>"; };
-		6F15519E1C7B0C8500B9EBBC /* libSPSlideTabBarController.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPSlideTabBarController.a; path = "../SPSlideTabBarController/build/Debug-iphoneos/libSPSlideTabBarController.a"; sourceTree = "<group>"; };
 		6F6D91C61C7AE94200CBD75D /* SPSlideTabBarControllerDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SPSlideTabBarControllerDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F6D91DF1C7AE94200CBD75D /* SPSlideTabBarControllerDemo.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SPSlideTabBarControllerDemo.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F6D91EA1C7AE94200CBD75D /* SPSlideTabBarControllerDemo.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SPSlideTabBarControllerDemo.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1DC626E2026DBF500CB7E07 /* libSPSlideTabBarController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libSPSlideTabBarController.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,7 +71,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6F15519F1C7B0C8500B9EBBC /* libSPSlideTabBarController.a in Frameworks */,
+				A1DC626D2026DBF500CB7E07 /* libSPSlideTabBarController.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,7 +165,7 @@
 		6F6D92131C7AE9E300CBD75D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				6F15519E1C7B0C8500B9EBBC /* libSPSlideTabBarController.a */,
+				A1DC626E2026DBF500CB7E07 /* libSPSlideTabBarController.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/SPSlideTabBarControllerDemo/SPSlideTabBarControllerDemo/HomeViewController.m
+++ b/SPSlideTabBarControllerDemo/SPSlideTabBarControllerDemo/HomeViewController.m
@@ -42,7 +42,7 @@
 
 - (instancetype)initWithDefaultViewControllersAndSizingTabBar:(BOOL)sizingTabBar initialIndex:(NSUInteger)initialIndex {
     
-    [[SPSlideTabBarItem appearance] setBarItemSelectedTextColor:[UIColor blueColor]];
+    [[SPSlideTabBarItem appearance] setBarItemSelectedTextColor:[UIColor whiteColor]];
     
     TableViewController *tableViewController = [[TableViewController alloc] init];
     [tableViewController setTitle:@"table"];
@@ -58,6 +58,7 @@
     
     self = [self initWithViewController:@[tableViewController, collectionViewController, scrollViewController, viewController] initTabIndex:initialIndex];
     
+    
     if (self) {
         _sizingTabBar = sizingTabBar;
     }
@@ -70,6 +71,7 @@
     // Do any additional setup after loading the view.
 
     [self.slideTabView setBackgroundColor:[UIColor colorWithWhite:0.8 alpha:1]];
+    [self.slideTabView changeIndicatorColor:[UIColor whiteColor]];
     [self setTitle:@"homeViewController"];
 }
 


### PR DESCRIPTION
When you call `changeIndicatorColor` method passing the color that you want

```objective-c
[self.slideTabView changeIndicatorColor:[UIColor whiteColor]];
```

the Tab Bar will change it's bottom line just like this screenshot:

![screen shot 2018-02-04 at 04 58 18](https://user-images.githubusercontent.com/8562684/35775042-1293bf8a-0968-11e8-9477-689b4ff7bc5c.png)

This PR solves #3 